### PR TITLE
Review + refactors

### DIFF
--- a/crates/bitcoind_rpc/src/bip158.rs
+++ b/crates/bitcoind_rpc/src/bip158.rs
@@ -30,7 +30,7 @@ pub struct FilterIter<'c, C> {
     // SPK inventory
     spks: Vec<ScriptBuf>,
     // local cp
-    cp: Option<CheckPoint>,
+    cp: Option<CheckPoint<BlockHash>>,
     // blocks map
     blocks: BTreeMap<Height, BlockHash>,
     // best height counter
@@ -53,7 +53,7 @@ impl<'c, C: RpcApi> FilterIter<'c, C> {
     }
 
     /// Construct [`FilterIter`] from a given `client` and [`CheckPoint`].
-    pub fn new_with_checkpoint(client: &'c C, cp: CheckPoint) -> Self {
+    pub fn new_with_checkpoint(client: &'c C, cp: CheckPoint<BlockHash>) -> Self {
         let mut filter_iter = Self::new_with_height(client, cp.height());
         filter_iter.cp = Some(cp);
         filter_iter
@@ -199,7 +199,7 @@ impl<C: RpcApi> Iterator for FilterIter<'_, C> {
 
 impl<C: RpcApi> FilterIter<'_, C> {
     /// Returns the point of agreement between `self` and the given `cp`.
-    fn find_base_with(&mut self, mut cp: CheckPoint) -> Result<BlockId, Error> {
+    fn find_base_with(&mut self, mut cp: CheckPoint<BlockHash>) -> Result<BlockId, Error> {
         loop {
             let height = cp.height();
             let fetched_hash = match self.blocks.get(&height) {
@@ -222,7 +222,7 @@ impl<C: RpcApi> FilterIter<'_, C> {
     ///
     /// Returns `None` if this [`FilterIter`] was not constructed using a [`CheckPoint`], or
     /// if no blocks have been fetched for example by using [`get_tip`](Self::get_tip).
-    pub fn chain_update(&mut self) -> Option<CheckPoint> {
+    pub fn chain_update(&mut self) -> Option<CheckPoint<BlockHash>> {
         if self.cp.is_none() || self.blocks.is_empty() {
             return None;
         }

--- a/crates/bitcoind_rpc/src/lib.rs
+++ b/crates/bitcoind_rpc/src/lib.rs
@@ -28,7 +28,7 @@ pub struct Emitter<'c, C> {
 
     /// The checkpoint of the last-emitted block that is in the best chain. If it is later found
     /// that the block is no longer in the best chain, it will be popped off from here.
-    last_cp: CheckPoint,
+    last_cp: CheckPoint<BlockHash>,
 
     /// The block result returned from rpc of the last-emitted block. As this result contains the
     /// next block's block hash (which we use to fetch the next block), we set this to `None`
@@ -53,7 +53,7 @@ impl<'c, C: bitcoincore_rpc::RpcApi> Emitter<'c, C> {
     ///
     /// `start_height` starts emission from a given height (if there are no conflicts with the
     /// original chain).
-    pub fn new(client: &'c C, last_cp: CheckPoint, start_height: u32) -> Self {
+    pub fn new(client: &'c C, last_cp: CheckPoint<BlockHash>, start_height: u32) -> Self {
         Self {
             client,
             start_height,
@@ -158,7 +158,7 @@ pub struct BlockEvent<B> {
     ///
     /// This is important as BDK structures require block-to-apply to be connected with another
     /// block in the original chain.
-    pub checkpoint: CheckPoint,
+    pub checkpoint: CheckPoint<BlockHash>,
 }
 
 impl<B> BlockEvent<B> {
@@ -192,7 +192,7 @@ enum PollResponse {
     NoMoreBlocks,
     /// Fetched block is not in the best chain.
     BlockNotInBestChain,
-    AgreementFound(bitcoincore_rpc_json::GetBlockResult, CheckPoint),
+    AgreementFound(bitcoincore_rpc_json::GetBlockResult, CheckPoint<BlockHash>),
     /// Force the genesis checkpoint down the receiver's throat.
     AgreementPointNotFound(BlockHash),
 }
@@ -253,7 +253,7 @@ where
 fn poll<C, V, F>(
     emitter: &mut Emitter<C>,
     get_item: F,
-) -> Result<Option<(CheckPoint, V)>, bitcoincore_rpc::Error>
+) -> Result<Option<(CheckPoint<BlockHash>, V)>, bitcoincore_rpc::Error>
 where
     C: bitcoincore_rpc::RpcApi,
     F: Fn(&BlockHash) -> Result<V, bitcoincore_rpc::Error>,
@@ -268,7 +268,7 @@ where
                 let new_cp = emitter
                     .last_cp
                     .clone()
-                    .push(BlockId { height, hash })
+                    .push_block_id(BlockId { height, hash })
                     .expect("must push");
                 emitter.last_cp = new_cp.clone();
                 emitter.last_block = Some(res);

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -280,7 +280,10 @@ fn process_block(
     block: Block,
     block_height: u32,
 ) -> anyhow::Result<()> {
-    recv_chain.apply_update(CheckPoint::from_header(&block.header, block_height))?;
+    recv_chain.apply_update(CheckPoint::blockhash_checkpoint_from_header(
+        &block.header,
+        block_height,
+    ))?;
     let _ = recv_graph.apply_block(block, block_height);
     Ok(())
 }

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -32,10 +32,10 @@ where
             }
         }
 
-        for (&height, &hash) in &changeset.blocks {
-            match hash {
-                Some(hash) => {
-                    extension.insert(height, hash);
+        for (&height, &data) in &changeset.blocks {
+            match data {
+                Some(data) => {
+                    extension.insert(height, data);
                 }
                 None => {
                     extension.remove(&height);
@@ -47,7 +47,7 @@ where
             Some(base) => base
                 .extend(extension)
                 .expect("extension is strictly greater than base"),
-            None => LocalChain::from_blocks(extension)?.tip(),
+            None => LocalChain::from_data(extension)?.tip(),
         };
         init_cp = new_tip;
     }
@@ -98,18 +98,13 @@ where
     }
 }
 
-impl LocalChain {
-    /// Get the genesis hash.
-    pub fn genesis_hash(&self) -> BlockHash {
-        self.tip.get(0).expect("genesis must exist").hash()
-    }
-
+impl LocalChain<BlockHash> {
     /// Construct [`LocalChain`] from genesis `hash`.
     #[must_use]
     pub fn from_genesis_hash(hash: BlockHash) -> (Self, ChangeSet) {
         let height = 0;
         let chain = Self {
-            tip: CheckPoint::new(BlockId { height, hash }),
+            tip: CheckPoint::from_data(height, hash),
         };
         let changeset = chain.initial_changeset();
         (chain, changeset)
@@ -131,45 +126,12 @@ impl LocalChain {
         Ok(chain)
     }
 
-    /// Construct a [`LocalChain`] from a given `checkpoint` tip.
-    pub fn from_tip(tip: CheckPoint) -> Result<Self, MissingGenesisError> {
-        let genesis_cp = tip.iter().last().expect("must have at least one element");
-        if genesis_cp.height() != 0 {
-            return Err(MissingGenesisError);
-        }
-        Ok(Self { tip })
-    }
-
     /// Constructs a [`LocalChain`] from a [`BTreeMap`] of height to [`BlockHash`].
     ///
     /// The [`BTreeMap`] enforces the height order. However, the caller must ensure the blocks are
     /// all of the same chain.
     pub fn from_blocks(blocks: BTreeMap<u32, BlockHash>) -> Result<Self, MissingGenesisError> {
-        if !blocks.contains_key(&0) {
-            return Err(MissingGenesisError);
-        }
-
-        let mut tip: Option<CheckPoint> = None;
-        for block in &blocks {
-            match tip {
-                Some(curr) => {
-                    tip = Some(
-                        curr.push(BlockId::from(block))
-                            .expect("BTreeMap is ordered"),
-                    )
-                }
-                None => tip = Some(CheckPoint::new(BlockId::from(block))),
-            }
-        }
-
-        Ok(Self {
-            tip: tip.expect("already checked to have genesis"),
-        })
-    }
-
-    /// Get the highest checkpoint.
-    pub fn tip(&self) -> CheckPoint {
-        self.tip.clone()
+        LocalChain::from_data(blocks)
     }
 
     /// Applies the given `update` to the chain.
@@ -296,29 +258,7 @@ impl LocalChain {
     ///
     /// Replacing the block hash of an existing checkpoint will result in an error.
     pub fn insert_block(&mut self, block_id: BlockId) -> Result<ChangeSet, AlterCheckPointError> {
-        if let Some(original_cp) = self.tip.get(block_id.height) {
-            let original_hash = original_cp.hash();
-            if original_hash != block_id.hash {
-                return Err(AlterCheckPointError {
-                    height: block_id.height,
-                    original_hash,
-                    update_hash: Some(block_id.hash),
-                });
-            }
-            return Ok(ChangeSet::default());
-        }
-
-        let mut changeset = ChangeSet::default();
-        changeset
-            .blocks
-            .insert(block_id.height, Some(block_id.hash));
-        self.apply_changeset(&changeset)
-            .map_err(|_| AlterCheckPointError {
-                height: 0,
-                original_hash: self.genesis_hash(),
-                update_hash: changeset.blocks.get(&0).cloned().flatten(),
-            })?;
-        Ok(changeset)
+        self.insert_data(block_id.height, block_id.hash)
     }
 
     /// Removes blocks from (and inclusive of) the given `block_id`.
@@ -528,7 +468,7 @@ where
 }
 
 /// The [`ChangeSet`] represents changes to [`LocalChain`].
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ChangeSet<H = BlockHash> {
     /// Changes to the [`LocalChain`] blocks.

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -10,19 +10,22 @@ use bitcoin::block::Header;
 use bitcoin::BlockHash;
 
 /// Apply `changeset` to the checkpoint.
-fn apply_changeset_to_checkpoint(
-    mut init_cp: CheckPoint,
-    changeset: &ChangeSet,
-) -> Result<CheckPoint, MissingGenesisError> {
+fn apply_changeset_to_checkpoint<H>(
+    mut init_cp: CheckPoint<H>,
+    changeset: &ChangeSet<H>,
+) -> Result<CheckPoint<H>, MissingGenesisError>
+where
+    H: Copy + core::fmt::Debug + bdk_core::ToBlockHash,
+{
     if let Some(start_height) = changeset.blocks.keys().next().cloned() {
         // changes after point of agreement
         let mut extension = BTreeMap::default();
         // point of agreement
-        let mut base: Option<CheckPoint> = None;
+        let mut base: Option<CheckPoint<H>> = None;
 
         for cp in init_cp.iter() {
             if cp.height() >= start_height {
-                extension.insert(cp.height(), cp.hash());
+                extension.insert(cp.height(), cp.data());
             } else {
                 base = Some(cp);
                 break;
@@ -42,7 +45,7 @@ fn apply_changeset_to_checkpoint(
 
         let new_tip = match base {
             Some(base) => base
-                .extend(extension.into_iter().map(BlockId::from))
+                .extend(extension)
                 .expect("extension is strictly greater than base"),
             None => LocalChain::from_blocks(extension)?.tip(),
         };
@@ -53,12 +56,24 @@ fn apply_changeset_to_checkpoint(
 }
 
 /// This is a local implementation of [`ChainOracle`].
-#[derive(Debug, Clone, PartialEq)]
-pub struct LocalChain {
-    tip: CheckPoint,
+#[derive(Debug, Clone)]
+pub struct LocalChain<H = BlockHash> {
+    tip: CheckPoint<H>,
 }
 
-impl ChainOracle for LocalChain {
+impl<H> PartialEq for LocalChain<H>
+where
+    H: Copy + core::cmp::PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.tip == other.tip
+    }
+}
+
+impl<H> ChainOracle for LocalChain<H>
+where
+    H: Copy,
+{
     type Error = Infallible;
 
     fn is_block_in_chain(
@@ -109,7 +124,7 @@ impl LocalChain {
         };
 
         let (mut chain, _) = Self::from_genesis_hash(genesis_hash);
-        chain.apply_changeset(&changeset)?;
+        chain.apply_blockhash_changeset(&changeset)?;
 
         debug_assert!(chain._check_changeset_is_applied(&changeset));
 
@@ -171,7 +186,10 @@ impl LocalChain {
     /// An error will occur if the update does not correctly connect with `self`.
     ///
     /// [module-level documentation]: crate::local_chain
-    pub fn apply_update(&mut self, update: CheckPoint) -> Result<ChangeSet, CannotConnectError> {
+    pub fn apply_update(
+        &mut self,
+        update: CheckPoint<BlockHash>,
+    ) -> Result<ChangeSet, CannotConnectError> {
         let (new_tip, changeset) = merge_chains(self.tip.clone(), update)?;
         self.tip = new_tip;
         debug_assert!(self._check_changeset_is_applied(&changeset));
@@ -265,12 +283,11 @@ impl LocalChain {
     }
 
     /// Apply the given `changeset`.
-    pub fn apply_changeset(&mut self, changeset: &ChangeSet) -> Result<(), MissingGenesisError> {
-        let old_tip = self.tip.clone();
-        let new_tip = apply_changeset_to_checkpoint(old_tip, changeset)?;
-        self.tip = new_tip;
-        debug_assert!(self._check_changeset_is_applied(changeset));
-        Ok(())
+    pub fn apply_blockhash_changeset(
+        &mut self,
+        changeset: &ChangeSet,
+    ) -> Result<(), MissingGenesisError> {
+        self.apply_changeset(changeset)
     }
 
     /// Insert a [`BlockId`].
@@ -314,7 +331,7 @@ impl LocalChain {
     /// This will fail with [`MissingGenesisError`] if the caller attempts to disconnect from the
     /// genesis block.
     pub fn disconnect_from(&mut self, block_id: BlockId) -> Result<ChangeSet, MissingGenesisError> {
-        let mut remove_from = Option::<CheckPoint>::None;
+        let mut remove_from = Option::<CheckPoint<BlockHash>>::None;
         let mut changeset = ChangeSet::default();
         for cp in self.tip().iter() {
             let cp_id = cp.block_id();
@@ -355,28 +372,33 @@ impl LocalChain {
     }
 
     /// Iterate over checkpoints in descending height order.
-    pub fn iter_checkpoints(&self) -> CheckPointIter {
+    pub fn iter_checkpoints(&self) -> CheckPointIter<BlockHash> {
         self.tip.iter()
     }
 
     fn _check_changeset_is_applied(&self, changeset: &ChangeSet) -> bool {
-        let mut curr_cp = self.tip.clone();
-        for (height, exp_hash) in changeset.blocks.iter().rev() {
-            match curr_cp.get(*height) {
-                Some(query_cp) => {
-                    if query_cp.height() != *height || Some(query_cp.hash()) != *exp_hash {
-                        return false;
-                    }
-                    curr_cp = query_cp;
-                }
-                None => {
-                    if exp_hash.is_some() {
-                        return false;
-                    }
-                }
-            }
+        self._check_data_changeset_is_applied(changeset)
+    }
+}
+
+impl<H> LocalChain<H> {
+    /// Get the highest checkpoint.
+    pub fn tip(&self) -> CheckPoint<H> {
+        self.tip.clone()
+    }
+
+    /// Get the genesis hash.
+    pub fn genesis_hash(&self) -> BlockHash {
+        self.tip.get(0).expect("genesis must exist").block_id().hash
+    }
+
+    /// Construct a [`LocalChain`] from a given `checkpoint` tip.
+    pub fn from_tip(tip: CheckPoint<H>) -> Result<Self, MissingGenesisError> {
+        let genesis_cp = tip.iter().last().expect("must have at least one element");
+        if genesis_cp.height() != 0 {
+            return Err(MissingGenesisError);
         }
-        true
+        Ok(Self { tip })
     }
 
     /// Get checkpoint at given `height` (if it exists).
@@ -384,7 +406,7 @@ impl LocalChain {
     /// This is a shorthand for calling [`CheckPoint::get`] on the [`tip`].
     ///
     /// [`tip`]: LocalChain::tip
-    pub fn get(&self, height: u32) -> Option<CheckPoint> {
+    pub fn get(&self, height: u32) -> Option<CheckPoint<H>> {
         self.tip.get(height)
     }
 
@@ -396,7 +418,7 @@ impl LocalChain {
     /// This is a shorthand for calling [`CheckPoint::range`] on the [`tip`].
     ///
     /// [`tip`]: LocalChain::tip
-    pub fn range<R>(&self, range: R) -> impl Iterator<Item = CheckPoint>
+    pub fn range<R>(&self, range: R) -> impl Iterator<Item = CheckPoint<H>>
     where
         R: RangeBounds<u32>,
     {
@@ -404,18 +426,127 @@ impl LocalChain {
     }
 }
 
+impl<H> LocalChain<H>
+where
+    H: Copy + core::fmt::Debug + bdk_core::ToBlockHash,
+{
+    /// Apply the given `changeset`.
+    pub fn apply_changeset(&mut self, changeset: &ChangeSet<H>) -> Result<(), MissingGenesisError> {
+        let old_tip = self.tip.clone();
+        let new_tip = apply_changeset_to_checkpoint(old_tip, changeset)?;
+        self.tip = new_tip;
+        debug_assert!(self._check_data_changeset_is_applied(changeset));
+        Ok(())
+    }
+
+    fn _check_data_changeset_is_applied(&self, changeset: &ChangeSet<H>) -> bool {
+        let mut curr_cp = self.tip.clone();
+        for (height, data) in changeset.blocks.iter().rev() {
+            match curr_cp.get(*height) {
+                Some(query_cp) => {
+                    if let Some(data) = data {
+                        if query_cp.height() != *height || query_cp.hash() != data.to_blockhash() {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
+                    curr_cp = query_cp;
+                }
+                None => {
+                    if data.is_some() {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    /// Insert data into a [`LocalChain`].
+    ///
+    /// # Errors
+    ///
+    /// Replacing the block hash of an existing checkpoint will result in an error.
+    pub fn insert_data(
+        &mut self,
+        height: u32,
+        data: H,
+    ) -> Result<ChangeSet<H>, AlterCheckPointError> {
+        if let Some(original_cp) = self.tip.get(height) {
+            let original_hash = original_cp.hash();
+            if original_hash != data.to_blockhash() {
+                return Err(AlterCheckPointError {
+                    height,
+                    original_hash,
+                    update_hash: Some(data.to_blockhash()),
+                });
+            }
+            return Ok(ChangeSet::default());
+        }
+
+        let mut changeset = ChangeSet::<H>::default();
+        changeset.blocks.insert(height, Some(data));
+        self.apply_changeset(&changeset)
+            .map_err(|_| AlterCheckPointError {
+                height: 0,
+                original_hash: self.genesis_hash(),
+                update_hash: Some(
+                    changeset
+                        .blocks
+                        .get(&0)
+                        .cloned()
+                        .flatten()
+                        .unwrap()
+                        .to_blockhash(),
+                ),
+            })?;
+        Ok(changeset)
+    }
+
+    /// Constructs a [`LocalChain`] from a [`BTreeMap`] of height and data.
+    ///
+    /// The [`BTreeMap`] enforces the height order. However, the caller must ensure the blocks are
+    /// all of the same chain.
+    pub fn from_data(blocks: BTreeMap<u32, H>) -> Result<Self, MissingGenesisError> {
+        if !blocks.contains_key(&0) {
+            return Err(MissingGenesisError);
+        }
+
+        let mut tip: Option<CheckPoint<H>> = None;
+        for (height, data) in &blocks {
+            match tip {
+                Some(curr) => tip = Some(curr.push(*height, *data).expect("BTreeMap is ordered")),
+                None => tip = Some(CheckPoint::from_data(*height, *data)),
+            }
+        }
+
+        Ok(Self {
+            tip: tip.expect("already checked to have genesis"),
+        })
+    }
+}
+
 /// The [`ChangeSet`] represents changes to [`LocalChain`].
 #[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct ChangeSet {
+pub struct ChangeSet<H = BlockHash> {
     /// Changes to the [`LocalChain`] blocks.
     ///
     /// The key represents the block height, and the value either represents added a new [`CheckPoint`]
     /// (if [`Some`]), or removing a [`CheckPoint`] (if [`None`]).
-    pub blocks: BTreeMap<u32, Option<BlockHash>>,
+    pub blocks: BTreeMap<u32, Option<H>>,
 }
 
-impl Merge for ChangeSet {
+impl<H> Default for ChangeSet<H> {
+    fn default() -> Self {
+        ChangeSet {
+            blocks: BTreeMap::default(),
+        }
+    }
+}
+
+impl<H> Merge for ChangeSet<H> {
     fn merge(&mut self, other: Self) {
         Merge::merge(&mut self.blocks, other.blocks)
     }
@@ -425,24 +556,24 @@ impl Merge for ChangeSet {
     }
 }
 
-impl<B: IntoIterator<Item = (u32, Option<BlockHash>)>> From<B> for ChangeSet {
-    fn from(blocks: B) -> Self {
+impl<H, I: IntoIterator<Item = (u32, Option<H>)>> From<I> for ChangeSet<H> {
+    fn from(blocks: I) -> Self {
         Self {
             blocks: blocks.into_iter().collect(),
         }
     }
 }
 
-impl FromIterator<(u32, Option<BlockHash>)> for ChangeSet {
-    fn from_iter<T: IntoIterator<Item = (u32, Option<BlockHash>)>>(iter: T) -> Self {
+impl<H> FromIterator<(u32, Option<H>)> for ChangeSet<H> {
+    fn from_iter<T: IntoIterator<Item = (u32, Option<H>)>>(iter: T) -> Self {
         Self {
             blocks: iter.into_iter().collect(),
         }
     }
 }
 
-impl FromIterator<(u32, BlockHash)> for ChangeSet {
-    fn from_iter<T: IntoIterator<Item = (u32, BlockHash)>>(iter: T) -> Self {
+impl<H> FromIterator<(u32, H)> for ChangeSet<H> {
+    fn from_iter<T: IntoIterator<Item = (u32, H)>>(iter: T) -> Self {
         Self {
             blocks: iter
                 .into_iter()
@@ -548,16 +679,16 @@ impl std::error::Error for ApplyHeaderError {}
 /// On success, a tuple is returned `(changeset, can_replace)`. If `can_replace` is true, then the
 /// `update_tip` can replace the `original_tip`.
 fn merge_chains(
-    original_tip: CheckPoint,
-    update_tip: CheckPoint,
-) -> Result<(CheckPoint, ChangeSet), CannotConnectError> {
+    original_tip: CheckPoint<BlockHash>,
+    update_tip: CheckPoint<BlockHash>,
+) -> Result<(CheckPoint<BlockHash>, ChangeSet), CannotConnectError> {
     let mut changeset = ChangeSet::default();
     let mut orig = original_tip.iter();
     let mut update = update_tip.iter();
     let mut curr_orig = None;
     let mut curr_update = None;
-    let mut prev_orig: Option<CheckPoint> = None;
-    let mut prev_update: Option<CheckPoint> = None;
+    let mut prev_orig: Option<CheckPoint<BlockHash>> = None;
+    let mut prev_update: Option<CheckPoint<BlockHash>> = None;
     let mut point_of_agreement_found = false;
     let mut prev_orig_was_invalidated = false;
     let mut potentially_invalidated_heights = vec![];

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -1,10 +1,12 @@
 //! The [`LocalChain`] is a local implementation of [`ChainOracle`].
 
 use core::convert::Infallible;
+use core::fmt;
 use core::ops::RangeBounds;
 
 use crate::collections::BTreeMap;
 use crate::{BlockId, ChainOracle, Merge};
+use bdk_core::ToBlockHash;
 pub use bdk_core::{CheckPoint, CheckPointIter};
 use bitcoin::block::Header;
 use bitcoin::BlockHash;
@@ -15,7 +17,7 @@ fn apply_changeset_to_checkpoint<H>(
     changeset: &ChangeSet<H>,
 ) -> Result<CheckPoint<H>, MissingGenesisError>
 where
-    H: Copy + core::fmt::Debug + bdk_core::ToBlockHash,
+    H: ToBlockHash + fmt::Debug + Copy,
 {
     if let Some(start_height) = changeset.blocks.keys().next().cloned() {
         // changes after point of agreement
@@ -61,19 +63,13 @@ pub struct LocalChain<H = BlockHash> {
     tip: CheckPoint<H>,
 }
 
-impl<H> PartialEq for LocalChain<H>
-where
-    H: Copy + core::cmp::PartialEq,
-{
+impl<H> PartialEq for LocalChain<H> {
     fn eq(&self, other: &Self) -> bool {
         self.tip == other.tip
     }
 }
 
-impl<H> ChainOracle for LocalChain<H>
-where
-    H: Copy,
-{
+impl<H> ChainOracle for LocalChain<H> {
     type Error = Infallible;
 
     fn is_block_in_chain(
@@ -98,32 +94,11 @@ where
     }
 }
 
+// Methods for `LocalChain<BlockHash>`
 impl LocalChain<BlockHash> {
     /// Construct [`LocalChain`] from genesis `hash`.
-    #[must_use]
     pub fn from_genesis_hash(hash: BlockHash) -> (Self, ChangeSet) {
-        let height = 0;
-        let chain = Self {
-            tip: CheckPoint::from_data(height, hash),
-        };
-        let changeset = chain.initial_changeset();
-        (chain, changeset)
-    }
-
-    /// Construct a [`LocalChain`] from an initial `changeset`.
-    pub fn from_changeset(changeset: ChangeSet) -> Result<Self, MissingGenesisError> {
-        let genesis_entry = changeset.blocks.get(&0).copied().flatten();
-        let genesis_hash = match genesis_entry {
-            Some(hash) => hash,
-            None => return Err(MissingGenesisError),
-        };
-
-        let (mut chain, _) = Self::from_genesis_hash(genesis_hash);
-        chain.apply_blockhash_changeset(&changeset)?;
-
-        debug_assert!(chain._check_changeset_is_applied(&changeset));
-
-        Ok(chain)
+        Self::from_genesis(hash)
     }
 
     /// Constructs a [`LocalChain`] from a [`BTreeMap`] of height to [`BlockHash`].
@@ -132,30 +107,6 @@ impl LocalChain<BlockHash> {
     /// all of the same chain.
     pub fn from_blocks(blocks: BTreeMap<u32, BlockHash>) -> Result<Self, MissingGenesisError> {
         LocalChain::from_data(blocks)
-    }
-
-    /// Applies the given `update` to the chain.
-    ///
-    /// The method returns [`ChangeSet`] on success. This represents the changes applied to `self`.
-    ///
-    /// There must be no ambiguity about which of the existing chain's blocks are still valid and
-    /// which are now invalid. That is, the new chain must implicitly connect to a definite block in
-    /// the existing chain and invalidate the block after it (if it exists) by including a block at
-    /// the same height but with a different hash to explicitly exclude it as a connection point.
-    ///
-    /// # Errors
-    ///
-    /// An error will occur if the update does not correctly connect with `self`.
-    ///
-    /// [module-level documentation]: crate::local_chain
-    pub fn apply_update(
-        &mut self,
-        update: CheckPoint<BlockHash>,
-    ) -> Result<ChangeSet, CannotConnectError> {
-        let (new_tip, changeset) = merge_chains(self.tip.clone(), update)?;
-        self.tip = new_tip;
-        debug_assert!(self._check_changeset_is_applied(&changeset));
-        Ok(changeset)
     }
 
     /// Update the chain with a given [`Header`] at `height` which you claim is connected to a existing block in the chain.
@@ -244,14 +195,6 @@ impl LocalChain<BlockHash> {
             })
     }
 
-    /// Apply the given `changeset`.
-    pub fn apply_blockhash_changeset(
-        &mut self,
-        changeset: &ChangeSet,
-    ) -> Result<(), MissingGenesisError> {
-        self.apply_changeset(changeset)
-    }
-
     /// Insert a [`BlockId`].
     ///
     /// # Errors
@@ -260,67 +203,9 @@ impl LocalChain<BlockHash> {
     pub fn insert_block(&mut self, block_id: BlockId) -> Result<ChangeSet, AlterCheckPointError> {
         self.insert_data(block_id.height, block_id.hash)
     }
-
-    /// Removes blocks from (and inclusive of) the given `block_id`.
-    ///
-    /// This will remove blocks with a height equal or greater than `block_id`, but only if
-    /// `block_id` exists in the chain.
-    ///
-    /// # Errors
-    ///
-    /// This will fail with [`MissingGenesisError`] if the caller attempts to disconnect from the
-    /// genesis block.
-    pub fn disconnect_from(&mut self, block_id: BlockId) -> Result<ChangeSet, MissingGenesisError> {
-        let mut remove_from = Option::<CheckPoint<BlockHash>>::None;
-        let mut changeset = ChangeSet::default();
-        for cp in self.tip().iter() {
-            let cp_id = cp.block_id();
-            if cp_id.height < block_id.height {
-                break;
-            }
-            changeset.blocks.insert(cp_id.height, None);
-            if cp_id == block_id {
-                remove_from = Some(cp);
-            }
-        }
-        self.tip = match remove_from.map(|cp| cp.prev()) {
-            // The checkpoint below the earliest checkpoint to remove will be the new tip.
-            Some(Some(new_tip)) => new_tip,
-            // If there is no checkpoint below the earliest checkpoint to remove, it means the
-            // "earliest checkpoint to remove" is the genesis block. We disallow removing the
-            // genesis block.
-            Some(None) => return Err(MissingGenesisError),
-            // If there is nothing to remove, we return an empty changeset.
-            None => return Ok(ChangeSet::default()),
-        };
-        Ok(changeset)
-    }
-
-    /// Derives an initial [`ChangeSet`], meaning that it can be applied to an empty chain to
-    /// recover the current chain.
-    pub fn initial_changeset(&self) -> ChangeSet {
-        ChangeSet {
-            blocks: self
-                .tip
-                .iter()
-                .map(|cp| {
-                    let block_id = cp.block_id();
-                    (block_id.height, Some(block_id.hash))
-                })
-                .collect(),
-        }
-    }
-
-    /// Iterate over checkpoints in descending height order.
-    pub fn iter_checkpoints(&self) -> CheckPointIter<BlockHash> {
-        self.tip.iter()
-    }
-
-    fn _check_changeset_is_applied(&self, changeset: &ChangeSet) -> bool {
-        self._check_data_changeset_is_applied(changeset)
-    }
 }
 
+// Methods for any `H`
 impl<H> LocalChain<H> {
     /// Get the highest checkpoint.
     pub fn tip(&self) -> CheckPoint<H> {
@@ -332,13 +217,9 @@ impl<H> LocalChain<H> {
         self.tip.get(0).expect("genesis must exist").block_id().hash
     }
 
-    /// Construct a [`LocalChain`] from a given `checkpoint` tip.
-    pub fn from_tip(tip: CheckPoint<H>) -> Result<Self, MissingGenesisError> {
-        let genesis_cp = tip.iter().last().expect("must have at least one element");
-        if genesis_cp.height() != 0 {
-            return Err(MissingGenesisError);
-        }
-        Ok(Self { tip })
+    /// Iterate over checkpoints in descending height order.
+    pub fn iter_checkpoints(&self) -> CheckPointIter<H> {
+        self.tip.iter()
     }
 
     /// Get checkpoint at given `height` (if it exists).
@@ -366,41 +247,106 @@ impl<H> LocalChain<H> {
     }
 }
 
+// Methods where `H: ToBlockHash`
 impl<H> LocalChain<H>
 where
-    H: Copy + core::fmt::Debug + bdk_core::ToBlockHash,
+    H: ToBlockHash + fmt::Debug + Copy,
 {
+    /// Constructs a [`LocalChain`] from genesis data.
+    pub fn from_genesis(data: H) -> (Self, ChangeSet<H>) {
+        let height = 0;
+        let chain = Self {
+            tip: CheckPoint::from_data(height, data),
+        };
+        let changeset = chain.initial_changeset();
+
+        (chain, changeset)
+    }
+
+    /// Constructs a [`LocalChain`] from a [`BTreeMap`] of height and data.
+    ///
+    /// The [`BTreeMap`] enforces the height order. However, the caller must ensure the blocks are
+    /// all of the same chain.
+    pub fn from_data(blocks: BTreeMap<u32, H>) -> Result<Self, MissingGenesisError> {
+        if !blocks.contains_key(&0) {
+            return Err(MissingGenesisError);
+        }
+
+        Ok(Self {
+            tip: CheckPoint::from_block_data(blocks).expect("blocks must be in order"),
+        })
+    }
+
+    /// Construct a [`LocalChain`] from an initial `changeset`.
+    pub fn from_changeset(changeset: ChangeSet<H>) -> Result<Self, MissingGenesisError> {
+        let genesis_entry = changeset.blocks.get(&0).copied().flatten();
+        let genesis_data = match genesis_entry {
+            Some(data) => data,
+            None => return Err(MissingGenesisError),
+        };
+
+        let (mut chain, _) = Self::from_genesis(genesis_data);
+        chain.apply_changeset(&changeset)?;
+
+        debug_assert!(chain._check_changeset_is_applied(&changeset));
+
+        Ok(chain)
+    }
+
+    /// Construct a [`LocalChain`] from a given `checkpoint` tip.
+    pub fn from_tip(tip: CheckPoint<H>) -> Result<Self, MissingGenesisError> {
+        let genesis_cp = tip.iter().last().expect("must have at least one element");
+        if genesis_cp.height() != 0 {
+            return Err(MissingGenesisError);
+        }
+
+        Ok(Self { tip })
+    }
+
+    /// Applies the given `update` to the chain.
+    ///
+    /// The method returns [`ChangeSet`] on success. This represents the changes applied to `self`.
+    ///
+    /// There must be no ambiguity about which of the existing chain's blocks are still valid and
+    /// which are now invalid. That is, the new chain must implicitly connect to a definite block in
+    /// the existing chain and invalidate the block after it (if it exists) by including a block at
+    /// the same height but with a different hash to explicitly exclude it as a connection point.
+    ///
+    /// # Errors
+    ///
+    /// An error will occur if the update does not correctly connect with `self`.
+    ///
+    /// [module-level documentation]: crate::local_chain
+    pub fn apply_update(
+        &mut self,
+        update: CheckPoint<H>,
+    ) -> Result<ChangeSet<H>, CannotConnectError> {
+        let (new_tip, changeset) = merge_chains(self.tip.clone(), update)?;
+        self.tip = new_tip;
+        debug_assert!(self._check_changeset_is_applied(&changeset));
+
+        Ok(changeset)
+    }
+
     /// Apply the given `changeset`.
     pub fn apply_changeset(&mut self, changeset: &ChangeSet<H>) -> Result<(), MissingGenesisError> {
         let old_tip = self.tip.clone();
         let new_tip = apply_changeset_to_checkpoint(old_tip, changeset)?;
         self.tip = new_tip;
-        debug_assert!(self._check_data_changeset_is_applied(changeset));
+        debug_assert!(self._check_changeset_is_applied(changeset));
         Ok(())
     }
 
-    fn _check_data_changeset_is_applied(&self, changeset: &ChangeSet<H>) -> bool {
-        let mut curr_cp = self.tip.clone();
-        for (height, data) in changeset.blocks.iter().rev() {
-            match curr_cp.get(*height) {
-                Some(query_cp) => {
-                    if let Some(data) = data {
-                        if query_cp.height() != *height || query_cp.hash() != data.to_blockhash() {
-                            return false;
-                        }
-                    } else {
-                        return false;
-                    }
-                    curr_cp = query_cp;
-                }
-                None => {
-                    if data.is_some() {
-                        return false;
-                    }
-                }
-            }
+    /// Derives an initial [`ChangeSet`], meaning that it can be applied to an empty chain to
+    /// recover the current chain.
+    pub fn initial_changeset(&self) -> ChangeSet<H> {
+        ChangeSet {
+            blocks: self
+                .tip
+                .iter()
+                .map(|cp| (cp.height(), Some(cp.data())))
+                .collect(),
         }
-        true
     }
 
     /// Insert data into a [`LocalChain`].
@@ -444,26 +390,64 @@ where
         Ok(changeset)
     }
 
-    /// Constructs a [`LocalChain`] from a [`BTreeMap`] of height and data.
+    /// Removes blocks from (and inclusive of) the given `block_id`.
     ///
-    /// The [`BTreeMap`] enforces the height order. However, the caller must ensure the blocks are
-    /// all of the same chain.
-    pub fn from_data(blocks: BTreeMap<u32, H>) -> Result<Self, MissingGenesisError> {
-        if !blocks.contains_key(&0) {
-            return Err(MissingGenesisError);
-        }
-
-        let mut tip: Option<CheckPoint<H>> = None;
-        for (height, data) in &blocks {
-            match tip {
-                Some(curr) => tip = Some(curr.push(*height, *data).expect("BTreeMap is ordered")),
-                None => tip = Some(CheckPoint::from_data(*height, *data)),
+    /// This will remove blocks with a height equal or greater than `block_id`, but only if
+    /// `block_id` exists in the chain.
+    ///
+    /// # Errors
+    ///
+    /// This will fail with [`MissingGenesisError`] if the caller attempts to disconnect from the
+    /// genesis block.
+    pub fn disconnect_from(
+        &mut self,
+        block_id: BlockId,
+    ) -> Result<ChangeSet<H>, MissingGenesisError> {
+        let mut remove_from = Option::<CheckPoint<H>>::None;
+        let mut changeset = ChangeSet::default();
+        for cp in self.tip().iter() {
+            let cp_id = cp.block_id();
+            if cp_id.height < block_id.height {
+                break;
+            }
+            changeset.blocks.insert(cp_id.height, None);
+            if cp_id == block_id {
+                remove_from = Some(cp);
             }
         }
+        self.tip = match remove_from.map(|cp| cp.prev()) {
+            // The checkpoint below the earliest checkpoint to remove will be the new tip.
+            Some(Some(new_tip)) => new_tip,
+            // If there is no checkpoint below the earliest checkpoint to remove, it means the
+            // "earliest checkpoint to remove" is the genesis block. We disallow removing the
+            // genesis block.
+            Some(None) => return Err(MissingGenesisError),
+            // If there is nothing to remove, we return an empty changeset.
+            None => return Ok(ChangeSet::default()),
+        };
+        Ok(changeset)
+    }
 
-        Ok(Self {
-            tip: tip.expect("already checked to have genesis"),
-        })
+    fn _check_changeset_is_applied(&self, changeset: &ChangeSet<H>) -> bool {
+        let mut curr_cp = self.tip.clone();
+        for (height, data) in changeset.blocks.iter().rev() {
+            match curr_cp.get(*height) {
+                Some(query_cp) => {
+                    if query_cp.height() != *height
+                        || Some(query_cp.hash()) != data.map(|b| b.to_blockhash())
+                    {
+                        return false;
+                    }
+                    curr_cp = query_cp;
+                }
+                None => {
+                    if data.is_some() {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
     }
 }
 
@@ -618,17 +602,20 @@ impl std::error::Error for ApplyHeaderError {}
 ///
 /// On success, a tuple is returned `(changeset, can_replace)`. If `can_replace` is true, then the
 /// `update_tip` can replace the `original_tip`.
-fn merge_chains(
-    original_tip: CheckPoint<BlockHash>,
-    update_tip: CheckPoint<BlockHash>,
-) -> Result<(CheckPoint<BlockHash>, ChangeSet), CannotConnectError> {
-    let mut changeset = ChangeSet::default();
+fn merge_chains<H>(
+    original_tip: CheckPoint<H>,
+    update_tip: CheckPoint<H>,
+) -> Result<(CheckPoint<H>, ChangeSet<H>), CannotConnectError>
+where
+    H: ToBlockHash + fmt::Debug + Copy,
+{
+    let mut changeset = ChangeSet::<H>::default();
     let mut orig = original_tip.iter();
     let mut update = update_tip.iter();
     let mut curr_orig = None;
     let mut curr_update = None;
-    let mut prev_orig: Option<CheckPoint<BlockHash>> = None;
-    let mut prev_update: Option<CheckPoint<BlockHash>> = None;
+    let mut prev_orig: Option<CheckPoint<H>> = None;
+    let mut prev_update: Option<CheckPoint<H>> = None;
     let mut point_of_agreement_found = false;
     let mut prev_orig_was_invalidated = false;
     let mut potentially_invalidated_heights = vec![];
@@ -654,7 +641,7 @@ fn merge_chains(
         match (curr_orig.as_ref(), curr_update.as_ref()) {
             // Update block that doesn't exist in the original chain
             (o, Some(u)) if Some(u.height()) > o.map(|o| o.height()) => {
-                changeset.blocks.insert(u.height(), Some(u.hash()));
+                changeset.blocks.insert(u.height(), Some(u.data()));
                 prev_update = curr_update.take();
             }
             // Original block that isn't in the update
@@ -704,7 +691,7 @@ fn merge_chains(
                 } else {
                     // We have an invalidation height so we set the height to the updated hash and
                     // also purge all the original chain block hashes above this block.
-                    changeset.blocks.insert(u.height(), Some(u.hash()));
+                    changeset.blocks.insert(u.height(), Some(u.data()));
                     for invalidated_height in potentially_invalidated_heights.drain(..) {
                         changeset.blocks.insert(invalidated_height, None);
                     }

--- a/crates/chain/tests/test_local_chain.rs
+++ b/crates/chain/tests/test_local_chain.rs
@@ -17,7 +17,7 @@ use proptest::prelude::*;
 struct TestLocalChain<'a> {
     name: &'static str,
     chain: LocalChain,
-    update: CheckPoint,
+    update: CheckPoint<BlockHash>,
     exp: ExpectedResult<'a>,
 }
 
@@ -651,7 +651,7 @@ fn checkpoint_insert() {
         .expect("test formed incorrectly, must construct checkpoint chain");
 
         assert_eq!(
-            chain.insert(t.to_insert.into()),
+            chain.insert_block_id(t.to_insert.into()),
             exp_final_chain,
             "unexpected final chain"
         );
@@ -825,7 +825,10 @@ fn generate_height_range_bounds(
     )
 }
 
-fn generate_checkpoints(max_height: u32, max_count: usize) -> impl Strategy<Value = CheckPoint> {
+fn generate_checkpoints(
+    max_height: u32,
+    max_count: usize,
+) -> impl Strategy<Value = CheckPoint<BlockHash>> {
     proptest::collection::btree_set(1..max_height, 0..max_count).prop_map(|mut heights| {
         heights.insert(0); // must have genesis
         CheckPoint::from_block_ids(heights.into_iter().map(|height| {

--- a/crates/chain/tests/test_local_chain.rs
+++ b/crates/chain/tests/test_local_chain.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "miniscript")]
 
+use std::collections::BTreeMap;
 use std::ops::{Bound, RangeBounds};
 
 use bdk_chain::{
@@ -370,6 +371,99 @@ fn local_chain_insert_block() {
         let mut chain = t.original;
         assert_eq!(
             chain.insert_block(t.insert.into()),
+            t.expected_result,
+            "[{}] unexpected result when inserting block",
+            i,
+        );
+        assert_eq!(chain, t.expected_final, "[{}] unexpected final chain", i,);
+    }
+}
+
+#[test]
+fn local_chain_insert_header() {
+    fn header(prev_blockhash: BlockHash) -> Header {
+        Header {
+            version: bitcoin::block::Version::default(),
+            prev_blockhash,
+            merkle_root: bitcoin::hash_types::TxMerkleNode::all_zeros(),
+            time: 0,
+            bits: bitcoin::CompactTarget::default(),
+            nonce: 0,
+        }
+    }
+
+    // Create consecutive headers of height `n`, where the genesis header is height 0.
+    fn build_headers(n: u32) -> Vec<Header> {
+        let mut headers = Vec::new();
+        let genesis = header(hash!("_"));
+        headers.push(genesis);
+        for i in 1..=n {
+            let prev = headers[(i - 1) as usize].block_hash();
+            headers.push(header(prev));
+        }
+        headers
+    }
+
+    let headers = build_headers(5);
+
+    fn local_chain(data: Vec<(u32, Header)>) -> LocalChain<Header> {
+        bdk_chain::local_chain::LocalChain::from_data(data.into_iter().collect::<BTreeMap<_, _>>())
+            .expect("chain must have genesis block")
+    }
+
+    struct TestCase {
+        original: LocalChain<Header>,
+        insert: (u32, Header),
+        expected_result: Result<ChangeSet<Header>, AlterCheckPointError>,
+        expected_final: LocalChain<Header>,
+    }
+
+    let test_cases = [
+        // Test case 1: start with only the genesis header and insert header at height 5.
+        TestCase {
+            original: local_chain(vec![(0, headers[0])]),
+            insert: (5, headers[5]),
+            expected_result: Ok([(5, Some(headers[5]))].into()),
+            expected_final: local_chain(vec![(0, headers[0]), (5, headers[5])]),
+        },
+        // Test case 2: start with headers at heights 0 and 3. Insert header at height 4.
+        TestCase {
+            original: local_chain(vec![(0, headers[0]), (3, headers[3])]),
+            insert: (4, headers[4]),
+            expected_result: Ok([(4, Some(headers[4]))].into()),
+            expected_final: local_chain(vec![(0, headers[0]), (3, headers[3]), (4, headers[4])]),
+        },
+        // Test case 3: start with headers at heights 0 and 4. Insert header at height 3.
+        TestCase {
+            original: local_chain(vec![(0, headers[0]), (4, headers[4])]),
+            insert: (3, headers[3]),
+            expected_result: Ok([(3, Some(headers[3]))].into()),
+            expected_final: local_chain(vec![(0, headers[0]), (3, headers[3]), (4, headers[4])]),
+        },
+        // Test case 4: start with headers at heights 0 and 2. Insert the same header at height 2.
+        TestCase {
+            original: local_chain(vec![(0, headers[0]), (2, headers[2])]),
+            insert: (2, headers[2]),
+            expected_result: Ok([].into()),
+            expected_final: local_chain(vec![(0, headers[0]), (2, headers[2])]),
+        },
+        // Test case 5: start with headers at heights 0 and 2. Insert conflicting header at height 2.
+        TestCase {
+            original: local_chain(vec![(0, headers[0]), (2, headers[2])]),
+            insert: (2, header(hash!("conflict"))),
+            expected_result: Err(AlterCheckPointError {
+                height: 2,
+                original_hash: headers[2].block_hash(),
+                update_hash: Some(header(hash!("conflict")).block_hash()),
+            }),
+            expected_final: local_chain(vec![(0, headers[0]), (2, headers[2])]),
+        },
+    ];
+
+    for (i, t) in test_cases.into_iter().enumerate() {
+        let mut chain = t.original;
+        assert_eq!(
+            chain.insert_data(t.insert.0, t.insert.1),
             t.expected_result,
             "[{}] unexpected result when inserting block",
             i,

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -1,7 +1,7 @@
 use core::ops::RangeBounds;
 
 use alloc::sync::Arc;
-use bitcoin::BlockHash;
+use bitcoin::{block::Header, BlockHash};
 
 use crate::BlockId;
 
@@ -9,16 +9,24 @@ use crate::BlockId;
 ///
 /// Checkpoints are cheaply cloneable and are useful to find the agreement point between two sparse
 /// block chains.
-#[derive(Debug, Clone)]
-pub struct CheckPoint(Arc<CPInner>);
+#[derive(Debug)]
+pub struct CheckPoint<H = Header>(Arc<CPInner<H>>);
+
+impl<H> Clone for CheckPoint<H> {
+    fn clone(&self) -> Self {
+        CheckPoint(Arc::clone(&self.0))
+    }
+}
 
 /// The internal contents of [`CheckPoint`].
-#[derive(Debug, Clone)]
-struct CPInner {
-    /// Block id (hash and height).
-    block: BlockId,
+#[derive(Debug)]
+struct CPInner<H> {
+    /// Block data.
+    block_id: BlockId,
+    /// Data.
+    data: H,
     /// Previous checkpoint (if any).
-    prev: Option<Arc<CPInner>>,
+    prev: Option<Arc<CPInner<H>>>,
 }
 
 /// When a `CPInner` is dropped we need to go back down the chain and manually remove any
@@ -26,7 +34,7 @@ struct CPInner {
 /// leads to recursive logic and stack overflows
 ///
 /// https://github.com/bitcoindevkit/bdk/issues/1634
-impl Drop for CPInner {
+impl<H> Drop for CPInner<H> {
     fn drop(&mut self) {
         // Take out `prev` so its `drop` won't be called when this drop is finished
         let mut current = self.prev.take();
@@ -49,7 +57,28 @@ impl Drop for CPInner {
     }
 }
 
-impl PartialEq for CheckPoint {
+/// Trait that converts [`CheckPoint`] `data` to [`BlockHash`].
+pub trait ToBlockHash {
+    /// Returns the [`BlockHash`] for the associated [`CheckPoint`] `data` type.
+    fn to_blockhash(&self) -> BlockHash;
+}
+
+impl ToBlockHash for BlockHash {
+    fn to_blockhash(&self) -> BlockHash {
+        *self
+    }
+}
+
+impl ToBlockHash for Header {
+    fn to_blockhash(&self) -> BlockHash {
+        self.block_hash()
+    }
+}
+
+impl<H> PartialEq for CheckPoint<H>
+where
+    H: core::cmp::PartialEq,
+{
     fn eq(&self, other: &Self) -> bool {
         let self_cps = self.iter().map(|cp| cp.block_id());
         let other_cps = other.iter().map(|cp| cp.block_id());
@@ -57,10 +86,47 @@ impl PartialEq for CheckPoint {
     }
 }
 
-impl CheckPoint {
-    /// Construct a new base block at the front of a linked list.
+impl CheckPoint<BlockHash> {
+    /// Construct a new base [`CheckPoint`] at the front of a linked list.
     pub fn new(block: BlockId) -> Self {
-        Self(Arc::new(CPInner { block, prev: None }))
+        CheckPoint::from_data(block.height, block.hash)
+    }
+
+    /// Construct a checkpoint from the given `header` and block `height`.
+    ///
+    /// If `header` is of the genesis block, the checkpoint won't have a `prev` node. Otherwise,
+    /// we return a checkpoint linked with the previous block.
+    #[deprecated(
+        since = "0.4.1",
+        note = "Please use [`CheckPoint::blockhash_checkpoint_from_header`] instead. To create a CheckPoint<Header>, please use [`CheckPoint::from_data`]."
+    )]
+    pub fn from_header(header: &bitcoin::block::Header, height: u32) -> Self {
+        CheckPoint::blockhash_checkpoint_from_header(header, height)
+    }
+
+    /// Construct a checkpoint from the given `header` and block `height`.
+    ///
+    /// If `header` is of the genesis block, the checkpoint won't have a [`prev`] node. Otherwise,
+    /// we return a checkpoint linked with the previous block.
+    ///
+    /// [`prev`]: CheckPoint::prev
+    pub fn blockhash_checkpoint_from_header(header: &bitcoin::block::Header, height: u32) -> Self {
+        let hash = header.block_hash();
+        let this_block_id = BlockId { height, hash };
+
+        let prev_height = match height.checked_sub(1) {
+            Some(h) => h,
+            None => return Self::new(this_block_id),
+        };
+
+        let prev_block_id = BlockId {
+            height: prev_height,
+            hash: header.prev_blockhash,
+        };
+
+        CheckPoint::new(prev_block_id)
+            .push_block_id(this_block_id)
+            .expect("must construct checkpoint")
     }
 
     /// Construct a checkpoint from a list of [`BlockId`]s in ascending height order.
@@ -78,87 +144,86 @@ impl CheckPoint {
         block_ids: impl IntoIterator<Item = BlockId>,
     ) -> Result<Self, Option<Self>> {
         let mut blocks = block_ids.into_iter();
-        let mut acc = CheckPoint::new(blocks.next().ok_or(None)?);
+        let block = blocks.next().ok_or(None)?;
+        let mut acc = CheckPoint::new(block);
         for id in blocks {
-            acc = acc.push(id).map_err(Some)?;
+            acc = acc.push_block_id(id).map_err(Some)?;
         }
         Ok(acc)
-    }
-
-    /// Construct a checkpoint from the given `header` and block `height`.
-    ///
-    /// If `header` is of the genesis block, the checkpoint won't have a [`prev`] node. Otherwise,
-    /// we return a checkpoint linked with the previous block.
-    ///
-    /// [`prev`]: CheckPoint::prev
-    pub fn from_header(header: &bitcoin::block::Header, height: u32) -> Self {
-        let hash = header.block_hash();
-        let this_block_id = BlockId { height, hash };
-
-        let prev_height = match height.checked_sub(1) {
-            Some(h) => h,
-            None => return Self::new(this_block_id),
-        };
-
-        let prev_block_id = BlockId {
-            height: prev_height,
-            hash: header.prev_blockhash,
-        };
-
-        CheckPoint::new(prev_block_id)
-            .push(this_block_id)
-            .expect("must construct checkpoint")
-    }
-
-    /// Puts another checkpoint onto the linked list representing the blockchain.
-    ///
-    /// Returns an `Err(self)` if the block you are pushing on is not at a greater height that the one you
-    /// are pushing on to.
-    pub fn push(self, block: BlockId) -> Result<Self, Self> {
-        if self.height() < block.height {
-            Ok(Self(Arc::new(CPInner {
-                block,
-                prev: Some(self.0),
-            })))
-        } else {
-            Err(self)
-        }
     }
 
     /// Extends the checkpoint linked list by a iterator of block ids.
     ///
     /// Returns an `Err(self)` if there is block which does not have a greater height than the
     /// previous one.
-    pub fn extend(self, blocks: impl IntoIterator<Item = BlockId>) -> Result<Self, Self> {
-        let mut curr = self.clone();
-        for block in blocks {
-            curr = curr.push(block).map_err(|_| self.clone())?;
-        }
-        Ok(curr)
+    pub fn extend_block_ids(
+        self,
+        blockdata: impl IntoIterator<Item = BlockId>,
+    ) -> Result<Self, Self> {
+        self.extend(
+            blockdata
+                .into_iter()
+                .map(|block| (block.height, block.hash)),
+        )
+    }
+
+    /// Inserts `block_id` at its height within the chain.
+    ///
+    /// The effect of `insert` depends on whether a height already exists. If it doesn't the
+    /// `block_id` we inserted and all pre-existing blocks higher than it will be re-inserted after
+    /// it. If the height already existed and has a conflicting block hash then it will be purged
+    /// along with all blocks following it. The returned chain will have a tip of the `block_id`
+    /// passed in. Of course, if the `block_id` was already present then this just returns `self`.
+    #[must_use]
+    pub fn insert_block_id(self, block_id: BlockId) -> Self {
+        self.insert(block_id.height, block_id.hash)
+    }
+
+    /// Puts another checkpoint onto the linked list representing the blockchain.
+    ///
+    /// Returns an `Err(self)` if the block you are pushing on is not at a greater height that the one you
+    /// are pushing on to.
+    pub fn push_block_id(self, block: BlockId) -> Result<Self, Self> {
+        self.push(block.height, block.hash)
+    }
+}
+
+impl<H> CheckPoint<H> {
+    /// Get a reference of the `data` of the checkpoint.
+    pub fn data_ref(&self) -> &H {
+        &self.0.data
+    }
+
+    /// Get the `data` of a the checkpoint.
+    pub fn data(&self) -> H
+    where
+        H: Clone,
+    {
+        self.0.data.clone()
     }
 
     /// Get the [`BlockId`] of the checkpoint.
     pub fn block_id(&self) -> BlockId {
-        self.0.block
+        self.0.block_id
     }
 
-    /// Get the height of the checkpoint.
+    /// Get the `height` of the checkpoint.
     pub fn height(&self) -> u32 {
-        self.0.block.height
+        self.block_id().height
     }
 
     /// Get the block hash of the checkpoint.
     pub fn hash(&self) -> BlockHash {
-        self.0.block.hash
+        self.block_id().hash
     }
 
-    /// Get the previous checkpoint in the chain
-    pub fn prev(&self) -> Option<CheckPoint> {
+    /// Get the previous checkpoint in the chain.
+    pub fn prev(&self) -> Option<CheckPoint<H>> {
         self.0.prev.clone().map(CheckPoint)
     }
 
     /// Iterate from this checkpoint in descending height.
-    pub fn iter(&self) -> CheckPointIter {
+    pub fn iter(&self) -> CheckPointIter<H> {
         self.clone().into_iter()
     }
 
@@ -173,7 +238,7 @@ impl CheckPoint {
     ///
     /// Note that we always iterate checkpoints in reverse height order (iteration starts at tip
     /// height).
-    pub fn range<R>(&self, range: R) -> impl Iterator<Item = CheckPoint>
+    pub fn range<R>(&self, range: R) -> impl Iterator<Item = CheckPoint<H>>
     where
         R: RangeBounds<u32>,
     {
@@ -191,8 +256,38 @@ impl CheckPoint {
                 core::ops::Bound::Unbounded => true,
             })
     }
+}
 
-    /// Inserts `block_id` at its height within the chain.
+impl<H> CheckPoint<H>
+where
+    H: Copy + core::fmt::Debug + ToBlockHash,
+{
+    /// Construct a new base [`CheckPoint`] from given `height` and `data` at the front of a linked
+    /// list.
+    pub fn from_data(height: u32, data: H) -> Self {
+        Self(Arc::new(CPInner {
+            block_id: BlockId {
+                height,
+                hash: data.to_blockhash(),
+            },
+            data,
+            prev: None,
+        }))
+    }
+
+    /// Extends the checkpoint linked list by a iterator containing `height` and `data`.
+    ///
+    /// Returns an `Err(self)` if there is block which does not have a greater height than the
+    /// previous one.
+    pub fn extend(self, blockdata: impl IntoIterator<Item = (u32, H)>) -> Result<Self, Self> {
+        let mut curr = self.clone();
+        for (height, data) in blockdata {
+            curr = curr.push(height, data).map_err(|_| self.clone())?;
+        }
+        Ok(curr)
+    }
+
+    /// Inserts `data` at its `height` within the chain.
     ///
     /// The effect of `insert` depends on whether a height already exists. If it doesn't the
     /// `block_id` we inserted and all pre-existing blocks higher than it will be re-inserted after
@@ -204,12 +299,12 @@ impl CheckPoint {
     ///
     /// This panics if called with a genesis block that differs from that of `self`.
     #[must_use]
-    pub fn insert(self, block_id: BlockId) -> Self {
+    pub fn insert(self, height: u32, data: H) -> Self {
         let mut cp = self.clone();
         let mut tail = vec![];
         let base = loop {
-            if cp.height() == block_id.height {
-                if cp.hash() == block_id.hash {
+            if cp.height() == height {
+                if cp.hash() == data.to_blockhash() {
                     return self;
                 }
                 assert_ne!(cp.height(), 0, "cannot replace genesis block");
@@ -219,16 +314,35 @@ impl CheckPoint {
                 break cp.prev().expect("can't be called on genesis block");
             }
 
-            if cp.height() < block_id.height {
+            if cp.height() < height {
                 break cp;
             }
 
-            tail.push(cp.block_id());
+            tail.push((cp.height(), cp.data()));
             cp = cp.prev().expect("will break before genesis block");
         };
 
-        base.extend(core::iter::once(block_id).chain(tail.into_iter().rev()))
+        base.extend(core::iter::once((height, data)).chain(tail.into_iter().rev()))
             .expect("tail is in order")
+    }
+
+    /// Puts another checkpoint onto the linked list representing the blockchain.
+    ///
+    /// Returns an `Err(self)` if the block you are pushing on is not at a greater height that the one you
+    /// are pushing on to.
+    pub fn push(self, height: u32, data: H) -> Result<Self, Self> {
+        if self.height() < height {
+            Ok(Self(Arc::new(CPInner {
+                block_id: BlockId {
+                    height,
+                    hash: data.to_blockhash(),
+                },
+                data,
+                prev: Some(self.0),
+            })))
+        } else {
+            Err(self)
+        }
     }
 
     /// This method tests for `self` and `other` to have equal internal pointers.
@@ -238,12 +352,12 @@ impl CheckPoint {
 }
 
 /// Iterates over checkpoints backwards.
-pub struct CheckPointIter {
-    current: Option<Arc<CPInner>>,
+pub struct CheckPointIter<H = Header> {
+    current: Option<Arc<CPInner<H>>>,
 }
 
-impl Iterator for CheckPointIter {
-    type Item = CheckPoint;
+impl<H> Iterator for CheckPointIter<H> {
+    type Item = CheckPoint<H>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let current = self.current.clone()?;
@@ -252,9 +366,9 @@ impl Iterator for CheckPointIter {
     }
 }
 
-impl IntoIterator for CheckPoint {
-    type Item = CheckPoint;
-    type IntoIter = CheckPointIter;
+impl<H> IntoIterator for CheckPoint<H> {
+    type Item = CheckPoint<H>;
+    type IntoIter = CheckPointIter<H>;
 
     fn into_iter(self) -> Self::IntoIter {
         CheckPointIter {

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::ops::RangeBounds;
 
 use alloc::sync::Arc;
@@ -10,7 +11,7 @@ use crate::BlockId;
 /// Checkpoints are cheaply cloneable and are useful to find the agreement point between two sparse
 /// block chains.
 #[derive(Debug)]
-pub struct CheckPoint<H = Header>(Arc<CPInner<H>>);
+pub struct CheckPoint<H = BlockHash>(Arc<CPInner<H>>);
 
 impl<H> Clone for CheckPoint<H> {
     fn clone(&self) -> Self {
@@ -21,7 +22,7 @@ impl<H> Clone for CheckPoint<H> {
 /// The internal contents of [`CheckPoint`].
 #[derive(Debug)]
 struct CPInner<H> {
-    /// Block data.
+    /// Block id
     block_id: BlockId,
     /// Data.
     data: H,
@@ -75,10 +76,7 @@ impl ToBlockHash for Header {
     }
 }
 
-impl<H> PartialEq for CheckPoint<H>
-where
-    H: core::cmp::PartialEq,
-{
+impl<H> PartialEq for CheckPoint<H> {
     fn eq(&self, other: &Self) -> bool {
         let self_cps = self.iter().map(|cp| cp.block_id());
         let other_cps = other.iter().map(|cp| cp.block_id());
@@ -86,6 +84,7 @@ where
     }
 }
 
+// Methods for `CheckPoint<BlockHash>`
 impl CheckPoint<BlockHash> {
     /// Construct a new base [`CheckPoint`] at the front of a linked list.
     pub fn new(block: BlockId) -> Self {
@@ -97,10 +96,10 @@ impl CheckPoint<BlockHash> {
     /// If `header` is of the genesis block, the checkpoint won't have a `prev` node. Otherwise,
     /// we return a checkpoint linked with the previous block.
     #[deprecated(
-        since = "0.4.1",
-        note = "Please use [`CheckPoint::blockhash_checkpoint_from_header`] instead. To create a CheckPoint<Header>, please use [`CheckPoint::from_data`]."
+        since = "0.5.0",
+        note = "Use `blockhash_checkpoint_from_header` instead."
     )]
-    pub fn from_header(header: &bitcoin::block::Header, height: u32) -> Self {
+    pub fn from_header(header: &Header, height: u32) -> Self {
         CheckPoint::blockhash_checkpoint_from_header(header, height)
     }
 
@@ -110,7 +109,7 @@ impl CheckPoint<BlockHash> {
     /// we return a checkpoint linked with the previous block.
     ///
     /// [`prev`]: CheckPoint::prev
-    pub fn blockhash_checkpoint_from_header(header: &bitcoin::block::Header, height: u32) -> Self {
+    pub fn blockhash_checkpoint_from_header(header: &Header, height: u32) -> Self {
         let hash = header.block_hash();
         let this_block_id = BlockId { height, hash };
 
@@ -143,13 +142,7 @@ impl CheckPoint<BlockHash> {
     pub fn from_block_ids(
         block_ids: impl IntoIterator<Item = BlockId>,
     ) -> Result<Self, Option<Self>> {
-        let mut blocks = block_ids.into_iter();
-        let block = blocks.next().ok_or(None)?;
-        let mut acc = CheckPoint::new(block);
-        for id in blocks {
-            acc = acc.push_block_id(id).map_err(Some)?;
-        }
-        Ok(acc)
+        Self::from_block_data(block_ids.into_iter().map(|b| (b.height, b.hash)))
     }
 
     /// Extends the checkpoint linked list by a iterator of block ids.
@@ -188,6 +181,7 @@ impl CheckPoint<BlockHash> {
     }
 }
 
+// Methods for any `H`
 impl<H> CheckPoint<H> {
     /// Get a reference of the `data` of the checkpoint.
     pub fn data_ref(&self) -> &H {
@@ -256,11 +250,17 @@ impl<H> CheckPoint<H> {
                 core::ops::Bound::Unbounded => true,
             })
     }
+
+    /// This method tests for `self` and `other` to have equal internal pointers.
+    pub fn eq_ptr(&self, other: &Self) -> bool {
+        Arc::as_ptr(&self.0) == Arc::as_ptr(&other.0)
+    }
 }
 
+// Methods where `H: ToBlockHash`
 impl<H> CheckPoint<H>
 where
-    H: Copy + core::fmt::Debug + ToBlockHash,
+    H: ToBlockHash + fmt::Debug + Copy,
 {
     /// Construct a new base [`CheckPoint`] from given `height` and `data` at the front of a linked
     /// list.
@@ -275,16 +275,31 @@ where
         }))
     }
 
+    /// New from an iterator of block data.
+    ///
+    /// Returns `Err(None)` if `blocks` doesn't yield any data. If the blocks are not in ascending
+    /// height order, then returns the last [`CheckPoint`] that would have been extended.
+    pub fn from_block_data(
+        blocks: impl IntoIterator<Item = (u32, H)>,
+    ) -> Result<Self, Option<Self>> {
+        let mut blocks = blocks.into_iter();
+        let (height, data) = blocks.next().ok_or(None)?;
+        let mut cp = CheckPoint::from_data(height, data);
+        cp = cp.extend(blocks)?;
+
+        Ok(cp)
+    }
+
     /// Extends the checkpoint linked list by a iterator containing `height` and `data`.
     ///
     /// Returns an `Err(self)` if there is block which does not have a greater height than the
     /// previous one.
     pub fn extend(self, blockdata: impl IntoIterator<Item = (u32, H)>) -> Result<Self, Self> {
-        let mut curr = self.clone();
+        let mut cp = self.clone();
         for (height, data) in blockdata {
-            curr = curr.push(height, data).map_err(|_| self.clone())?;
+            cp = cp.push(height, data)?;
         }
-        Ok(curr)
+        Ok(cp)
     }
 
     /// Inserts `data` at its `height` within the chain.
@@ -344,15 +359,10 @@ where
             Err(self)
         }
     }
-
-    /// This method tests for `self` and `other` to have equal internal pointers.
-    pub fn eq_ptr(&self, other: &Self) -> bool {
-        Arc::as_ptr(&self.0) == Arc::as_ptr(&other.0)
-    }
 }
 
 /// Iterates over checkpoints backwards.
-pub struct CheckPointIter<H = Header> {
+pub struct CheckPointIter<H> {
     current: Option<Arc<CPInner<H>>>,
 }
 

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -4,7 +4,7 @@ use crate::{
     collections::{BTreeMap, HashMap, HashSet},
     CheckPoint, ConfirmationBlockTime, Indexed,
 };
-use bitcoin::{OutPoint, Script, ScriptBuf, Txid};
+use bitcoin::{BlockHash, OutPoint, Script, ScriptBuf, Txid};
 
 type InspectSync<I> = dyn FnMut(SyncItem<I>, SyncProgress) + Send + 'static;
 
@@ -112,8 +112,8 @@ impl From<ScriptBuf> for SpkWithExpectedTxids {
 ///
 /// Construct with [`SyncRequest::builder`].
 #[must_use]
-pub struct SyncRequestBuilder<I = ()> {
-    inner: SyncRequest<I>,
+pub struct SyncRequestBuilder<I = (), B = BlockHash> {
+    inner: SyncRequest<I, B>,
 }
 
 impl SyncRequestBuilder<()> {
@@ -123,11 +123,11 @@ impl SyncRequestBuilder<()> {
     }
 }
 
-impl<I> SyncRequestBuilder<I> {
+impl<I, B> SyncRequestBuilder<I, B> {
     /// Set the initial chain tip for the sync request.
     ///
     /// This is used to update [`LocalChain`](../../bdk_chain/local_chain/struct.LocalChain.html).
-    pub fn chain_tip(mut self, cp: CheckPoint) -> Self {
+    pub fn chain_tip(mut self, cp: CheckPoint<B>) -> Self {
         self.inner.chain_tip = Some(cp);
         self
     }
@@ -140,6 +140,7 @@ impl<I> SyncRequestBuilder<I> {
     /// [`KeychainTxOutIndex`](../../bdk_chain/indexer/keychain_txout/struct.KeychainTxOutIndex.html).
     ///
     /// ```rust
+    /// # use bdk_chain::bitcoin::BlockHash;
     /// # use bdk_chain::spk_client::SyncRequest;
     /// # use bdk_chain::indexer::keychain_txout::KeychainTxOutIndex;
     /// # use bdk_chain::miniscript::{Descriptor, DescriptorPublicKey};
@@ -157,7 +158,7 @@ impl<I> SyncRequestBuilder<I> {
     /// let (newly_revealed_spks, _changeset) = indexer
     ///     .reveal_to_target("descriptor_a", 21)
     ///     .expect("keychain must exist");
-    /// let _request = SyncRequest::builder()
+    /// let _request: SyncRequest<u32, BlockHash> = SyncRequest::builder()
     ///     .spks_with_indexes(newly_revealed_spks)
     ///     .build();
     ///
@@ -165,7 +166,7 @@ impl<I> SyncRequestBuilder<I> {
     /// // keychains. Each spk will be indexed with `(&'static str, u32)` where `&'static str` is
     /// // the keychain identifier and `u32` is the derivation index.
     /// let all_revealed_spks = indexer.revealed_spks(..);
-    /// let _request = SyncRequest::builder()
+    /// let _request: SyncRequest<(&str, u32), BlockHash> = SyncRequest::builder()
     ///     .spks_with_indexes(all_revealed_spks)
     ///     .build();
     /// # Ok::<_, bdk_chain::keychain_txout::InsertDescriptorError<_>>(())
@@ -211,7 +212,7 @@ impl<I> SyncRequestBuilder<I> {
     }
 
     /// Build the [`SyncRequest`].
-    pub fn build(self) -> SyncRequest<I> {
+    pub fn build(self) -> SyncRequest<I, B> {
         self.inner
     }
 }
@@ -239,9 +240,9 @@ impl<I> SyncRequestBuilder<I> {
 ///     .build();
 /// ```
 #[must_use]
-pub struct SyncRequest<I = ()> {
+pub struct SyncRequest<I = (), B = BlockHash> {
     start_time: u64,
-    chain_tip: Option<CheckPoint>,
+    chain_tip: Option<CheckPoint<B>>,
     spks: VecDeque<(I, ScriptBuf)>,
     spks_consumed: usize,
     spk_expected_txids: HashMap<ScriptBuf, HashSet<Txid>>,
@@ -252,13 +253,13 @@ pub struct SyncRequest<I = ()> {
     inspect: Box<InspectSync<I>>,
 }
 
-impl<I> From<SyncRequestBuilder<I>> for SyncRequest<I> {
-    fn from(builder: SyncRequestBuilder<I>) -> Self {
+impl<I, B> From<SyncRequestBuilder<I, B>> for SyncRequest<I, B> {
+    fn from(builder: SyncRequestBuilder<I, B>) -> Self {
         builder.inner
     }
 }
 
-impl<I> SyncRequest<I> {
+impl<I, B> SyncRequest<I, B> {
     /// Start building [`SyncRequest`] with a given `start_time`.
     ///
     /// `start_time` specifies the start time of sync. Chain sources can use this value to set
@@ -267,7 +268,7 @@ impl<I> SyncRequest<I> {
     ///
     /// Use [`SyncRequest::builder`] to use the current timestamp as `start_time` (this requires
     /// `feature = "std"`).
-    pub fn builder_at(start_time: u64) -> SyncRequestBuilder<I> {
+    pub fn builder_at(start_time: u64) -> SyncRequestBuilder<I, B> {
         SyncRequestBuilder {
             inner: Self {
                 start_time,
@@ -290,7 +291,7 @@ impl<I> SyncRequest<I> {
     /// is not available.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn builder() -> SyncRequestBuilder<I> {
+    pub fn builder() -> SyncRequestBuilder<I, B> {
         let start_time = std::time::UNIX_EPOCH
             .elapsed()
             .expect("failed to get current timestamp")
@@ -316,7 +317,7 @@ impl<I> SyncRequest<I> {
     }
 
     /// Get the chain tip [`CheckPoint`] of this request (if any).
-    pub fn chain_tip(&self) -> Option<CheckPoint> {
+    pub fn chain_tip(&self) -> Option<CheckPoint<B>> {
         self.chain_tip.clone()
     }
 
@@ -363,17 +364,17 @@ impl<I> SyncRequest<I> {
     pub fn iter_spks_with_expected_txids(
         &mut self,
     ) -> impl ExactSizeIterator<Item = SpkWithExpectedTxids> + '_ {
-        SyncIter::<I, SpkWithExpectedTxids>::new(self)
+        SyncIter::<I, B, SpkWithExpectedTxids>::new(self)
     }
 
     /// Iterate over [`Txid`]s contained in this request.
     pub fn iter_txids(&mut self) -> impl ExactSizeIterator<Item = Txid> + '_ {
-        SyncIter::<I, Txid>::new(self)
+        SyncIter::<I, B, Txid>::new(self)
     }
 
     /// Iterate over [`OutPoint`]s contained in this request.
     pub fn iter_outpoints(&mut self) -> impl ExactSizeIterator<Item = OutPoint> + '_ {
-        SyncIter::<I, OutPoint>::new(self)
+        SyncIter::<I, B, OutPoint>::new(self)
     }
 
     fn _call_inspect(&mut self, item: SyncItem<I>) {
@@ -387,14 +388,14 @@ impl<I> SyncRequest<I> {
 /// See also [`SyncRequest`].
 #[must_use]
 #[derive(Debug)]
-pub struct SyncResponse<A = ConfirmationBlockTime> {
+pub struct SyncResponse<B = BlockHash, A = ConfirmationBlockTime> {
     /// Relevant transaction data discovered during the scan.
     pub tx_update: crate::TxUpdate<A>,
     /// Changes to the chain discovered during the scan.
-    pub chain_update: Option<CheckPoint>,
+    pub chain_update: Option<CheckPoint<B>>,
 }
 
-impl<A> Default for SyncResponse<A> {
+impl<B, A> Default for SyncResponse<B, A> {
     fn default() -> Self {
         Self {
             tx_update: Default::default(),
@@ -407,15 +408,15 @@ impl<A> Default for SyncResponse<A> {
 ///
 /// Construct with [`FullScanRequest::builder`].
 #[must_use]
-pub struct FullScanRequestBuilder<K> {
-    inner: FullScanRequest<K>,
+pub struct FullScanRequestBuilder<K, B = BlockHash> {
+    inner: FullScanRequest<K, B>,
 }
 
-impl<K: Ord> FullScanRequestBuilder<K> {
+impl<K: Ord, B> FullScanRequestBuilder<K, B> {
     /// Set the initial chain tip for the full scan request.
     ///
     /// This is used to update [`LocalChain`](../../bdk_chain/local_chain/struct.LocalChain.html).
-    pub fn chain_tip(mut self, tip: CheckPoint) -> Self {
+    pub fn chain_tip(mut self, tip: CheckPoint<B>) -> Self {
         self.inner.chain_tip = Some(tip);
         self
     }
@@ -442,7 +443,7 @@ impl<K: Ord> FullScanRequestBuilder<K> {
     }
 
     /// Build the [`FullScanRequest`].
-    pub fn build(self) -> FullScanRequest<K> {
+    pub fn build(self) -> FullScanRequest<K, B> {
         self.inner
     }
 }
@@ -455,20 +456,20 @@ impl<K: Ord> FullScanRequestBuilder<K> {
 /// used scripts is not known. The full scan process also updates the chain from the given
 /// [`chain_tip`](FullScanRequestBuilder::chain_tip) (if provided).
 #[must_use]
-pub struct FullScanRequest<K> {
+pub struct FullScanRequest<K, B = BlockHash> {
     start_time: u64,
-    chain_tip: Option<CheckPoint>,
+    chain_tip: Option<CheckPoint<B>>,
     spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = Indexed<ScriptBuf>> + Send>>,
     inspect: Box<InspectFullScan<K>>,
 }
 
-impl<K> From<FullScanRequestBuilder<K>> for FullScanRequest<K> {
-    fn from(builder: FullScanRequestBuilder<K>) -> Self {
+impl<K, B> From<FullScanRequestBuilder<K, B>> for FullScanRequest<K, B> {
+    fn from(builder: FullScanRequestBuilder<K, B>) -> Self {
         builder.inner
     }
 }
 
-impl<K: Ord + Clone> FullScanRequest<K> {
+impl<K: Ord + Clone, B> FullScanRequest<K, B> {
     /// Start building a [`FullScanRequest`] with a given `start_time`.
     ///
     /// `start_time` specifies the start time of sync. Chain sources can use this value to set
@@ -477,7 +478,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
     ///
     /// Use [`FullScanRequest::builder`] to use the current timestamp as `start_time` (this
     /// requires `feature = "std`).
-    pub fn builder_at(start_time: u64) -> FullScanRequestBuilder<K> {
+    pub fn builder_at(start_time: u64) -> FullScanRequestBuilder<K, B> {
         FullScanRequestBuilder {
             inner: Self {
                 start_time,
@@ -494,7 +495,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
     /// "std"` is not available.
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn builder() -> FullScanRequestBuilder<K> {
+    pub fn builder() -> FullScanRequestBuilder<K, B> {
         let start_time = std::time::UNIX_EPOCH
             .elapsed()
             .expect("failed to get current timestamp")
@@ -508,7 +509,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
     }
 
     /// Get the chain tip [`CheckPoint`] of this request (if any).
-    pub fn chain_tip(&self) -> Option<CheckPoint> {
+    pub fn chain_tip(&self) -> Option<CheckPoint<B>> {
         self.chain_tip.clone()
     }
 
@@ -540,17 +541,17 @@ impl<K: Ord + Clone> FullScanRequest<K> {
 /// See also [`FullScanRequest`].
 #[must_use]
 #[derive(Debug)]
-pub struct FullScanResponse<K, A = ConfirmationBlockTime> {
+pub struct FullScanResponse<K, B = BlockHash, A = ConfirmationBlockTime> {
     /// Relevant transaction data discovered during the scan.
     pub tx_update: crate::TxUpdate<A>,
     /// Last active indices for the corresponding keychains (`K`). An index is active if it had a
     /// transaction associated with the script pubkey at that index.
     pub last_active_indices: BTreeMap<K, u32>,
     /// Changes to the chain discovered during the scan.
-    pub chain_update: Option<CheckPoint>,
+    pub chain_update: Option<CheckPoint<B>>,
 }
 
-impl<K, A> Default for FullScanResponse<K, A> {
+impl<K, B, A> Default for FullScanResponse<K, B, A> {
     fn default() -> Self {
         Self {
             tx_update: Default::default(),
@@ -576,13 +577,13 @@ impl<K: Ord + Clone> Iterator for KeychainSpkIter<'_, K> {
     }
 }
 
-struct SyncIter<'r, I, Item> {
-    request: &'r mut SyncRequest<I>,
+struct SyncIter<'r, I, B, Item> {
+    request: &'r mut SyncRequest<I, B>,
     marker: core::marker::PhantomData<Item>,
 }
 
-impl<'r, I, Item> SyncIter<'r, I, Item> {
-    fn new(request: &'r mut SyncRequest<I>) -> Self {
+impl<'r, I, B, Item> SyncIter<'r, I, B, Item> {
+    fn new(request: &'r mut SyncRequest<I, B>) -> Self {
         Self {
             request,
             marker: core::marker::PhantomData,
@@ -590,9 +591,12 @@ impl<'r, I, Item> SyncIter<'r, I, Item> {
     }
 }
 
-impl<'r, I, Item> ExactSizeIterator for SyncIter<'r, I, Item> where SyncIter<'r, I, Item>: Iterator {}
+impl<'r, I, B, Item> ExactSizeIterator for SyncIter<'r, I, B, Item> where
+    SyncIter<'r, I, B, Item>: Iterator
+{
+}
 
-impl<I> Iterator for SyncIter<'_, I, SpkWithExpectedTxids> {
+impl<I, B> Iterator for SyncIter<'_, I, B, SpkWithExpectedTxids> {
     type Item = SpkWithExpectedTxids;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -605,7 +609,7 @@ impl<I> Iterator for SyncIter<'_, I, SpkWithExpectedTxids> {
     }
 }
 
-impl<I> Iterator for SyncIter<'_, I, Txid> {
+impl<I, B> Iterator for SyncIter<'_, I, B, Txid> {
     type Item = Txid;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -618,7 +622,7 @@ impl<I> Iterator for SyncIter<'_, I, Txid> {
     }
 }
 
-impl<I> Iterator for SyncIter<'_, I, OutPoint> {
+impl<I, B> Iterator for SyncIter<'_, I, B, OutPoint> {
     type Item = OutPoint;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/core/tests/test_checkpoint.rs
+++ b/crates/core/tests/test_checkpoint.rs
@@ -22,7 +22,7 @@ fn checkpoint_insert_existing() {
                 .get(j as u32)
                 .expect("cp of height must exist")
                 .block_id();
-            let new_cp_chain = cp_chain.clone().insert(block_to_insert);
+            let new_cp_chain = cp_chain.clone().insert_block_id(block_to_insert);
 
             assert_eq!(
                 new_cp_chain, cp_chain,
@@ -47,7 +47,7 @@ fn checkpoint_destruction_is_sound() {
     for height in 1u32..end {
         let hash = bitcoin::hashes::Hash::hash(height.to_be_bytes().as_slice());
         let block = BlockId { height, hash };
-        cp = cp.push(block).unwrap();
+        cp = cp.push_block_id(block).unwrap();
     }
     assert_eq!(cp.iter().count() as u32, end);
 }

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -489,8 +489,8 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
 /// fetched to construct checkpoint updates with the proper [`BlockHash`] in case of re-org.
 fn fetch_tip_and_latest_blocks(
     client: &impl ElectrumApi,
-    prev_tip: CheckPoint,
-) -> Result<(CheckPoint, BTreeMap<u32, BlockHash>), Error> {
+    prev_tip: CheckPoint<BlockHash>,
+) -> Result<(CheckPoint<BlockHash>, BTreeMap<u32, BlockHash>), Error> {
     let HeaderNotification { height, .. } = client.block_headers_subscribe()?;
     let new_tip_height = height as u32;
 
@@ -514,7 +514,7 @@ fn fetch_tip_and_latest_blocks(
 
     // Find the "point of agreement" (if any).
     let agreement_cp = {
-        let mut agreement_cp = Option::<CheckPoint>::None;
+        let mut agreement_cp = Option::<CheckPoint<BlockHash>>::None;
         for cp in prev_tip.iter() {
             let cp_block = cp.block_id();
             let hash = match new_blocks.get(&cp_block.height) {
@@ -549,7 +549,7 @@ fn fetch_tip_and_latest_blocks(
         })
         .fold(agreement_cp, |prev_cp, block| {
             Some(match prev_cp {
-                Some(cp) => cp.push(block).expect("must extend checkpoint"),
+                Some(cp) => cp.push_block_id(block).expect("must extend checkpoint"),
                 None => CheckPoint::new(block),
             })
         })
@@ -561,10 +561,10 @@ fn fetch_tip_and_latest_blocks(
 // Add a corresponding checkpoint per anchor height if it does not yet exist. Checkpoints should not
 // surpass `latest_blocks`.
 fn chain_update(
-    mut tip: CheckPoint,
+    mut tip: CheckPoint<BlockHash>,
     latest_blocks: &BTreeMap<u32, BlockHash>,
     anchors: impl Iterator<Item = (ConfirmationBlockTime, Txid)>,
-) -> Result<CheckPoint, Error> {
+) -> Result<CheckPoint<BlockHash>, Error> {
     for (anchor, _txid) in anchors {
         let height = anchor.block_id.height;
 
@@ -575,7 +575,7 @@ fn chain_update(
                 Some(&hash) => hash,
                 None => anchor.block_id.hash,
             };
-            tip = tip.insert(BlockId { hash, height });
+            tip = tip.insert_block_id(BlockId { hash, height });
         }
     }
     Ok(tip)

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -223,9 +223,9 @@ async fn fetch_block<S: Sleeper>(
 async fn chain_update<S: Sleeper>(
     client: &esplora_client::AsyncClient<S>,
     latest_blocks: &BTreeMap<u32, BlockHash>,
-    local_tip: &CheckPoint,
+    local_tip: &CheckPoint<BlockHash>,
     anchors: &BTreeSet<(ConfirmationBlockTime, Txid)>,
-) -> Result<CheckPoint, Error> {
+) -> Result<CheckPoint<BlockHash>, Error> {
     let mut point_of_agreement = None;
     let mut conflicts = vec![];
     for local_cp in local_tip.iter() {
@@ -250,7 +250,7 @@ async fn chain_update<S: Sleeper>(
     let mut tip = point_of_agreement.expect("remote esplora should have same genesis block");
 
     tip = tip
-        .extend(conflicts.into_iter().rev())
+        .extend_block_ids(conflicts.into_iter().rev())
         .expect("evicted are in order");
 
     for (anchor, _txid) in anchors {
@@ -260,14 +260,14 @@ async fn chain_update<S: Sleeper>(
                 Some(hash) => hash,
                 None => continue,
             };
-            tip = tip.insert(BlockId { height, hash });
+            tip = tip.insert_block_id(BlockId { height, hash });
         }
     }
 
     // insert the most recent blocks at the tip to make sure we update the tip and make the update
     // robust.
     for (&height, &hash) in latest_blocks.iter() {
-        tip = tip.insert(BlockId { height, hash });
+        tip = tip.insert_block_id(BlockId { height, hash });
     }
 
     Ok(tip)

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -208,9 +208,9 @@ fn fetch_block(
 fn chain_update(
     client: &esplora_client::BlockingClient,
     latest_blocks: &BTreeMap<u32, BlockHash>,
-    local_tip: &CheckPoint,
+    local_tip: &CheckPoint<BlockHash>,
     anchors: &BTreeSet<(ConfirmationBlockTime, Txid)>,
-) -> Result<CheckPoint, Error> {
+) -> Result<CheckPoint<BlockHash>, Error> {
     let mut point_of_agreement = None;
     let mut conflicts = vec![];
     for local_cp in local_tip.iter() {
@@ -235,7 +235,7 @@ fn chain_update(
     let mut tip = point_of_agreement.expect("remote esplora should have same genesis block");
 
     tip = tip
-        .extend(conflicts.into_iter().rev())
+        .extend_block_ids(conflicts.into_iter().rev())
         .expect("evicted are in order");
 
     for (anchor, _) in anchors {
@@ -245,14 +245,14 @@ fn chain_update(
                 Some(hash) => hash,
                 None => continue,
             };
-            tip = tip.insert(BlockId { height, hash });
+            tip = tip.insert_block_id(BlockId { height, hash });
         }
     }
 
     // insert the most recent blocks at the tip to make sure we update the tip and make the update
     // robust.
     for (&height, &hash) in latest_blocks.iter() {
-        tip = tip.insert(BlockId { height, hash });
+        tip = tip.insert_block_id(BlockId { height, hash });
     }
 
     Ok(tip)

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -292,7 +292,7 @@ impl TestEnv {
     }
 
     /// Create a checkpoint linked list of all the blocks in the chain.
-    pub fn make_checkpoint_tip(&self) -> CheckPoint {
+    pub fn make_checkpoint_tip(&self) -> CheckPoint<BlockHash> {
         CheckPoint::from_block_ids((0_u32..).map_while(|height| {
             self.bitcoind
                 .client

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -814,7 +814,7 @@ pub fn init_or_load<CS: clap::Subcommand, S: clap::Args>(
             let chain = Mutex::new({
                 let (mut chain, _) =
                     LocalChain::from_genesis_hash(constants::genesis_block(network).block_hash());
-                chain.apply_changeset(&changeset.local_chain)?;
+                chain.apply_blockhash_changeset(&changeset.local_chain)?;
                 chain
             });
 

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -814,7 +814,7 @@ pub fn init_or_load<CS: clap::Subcommand, S: clap::Args>(
             let chain = Mutex::new({
                 let (mut chain, _) =
                     LocalChain::from_genesis_hash(constants::genesis_block(network).block_hash());
-                chain.apply_blockhash_changeset(&changeset.local_chain)?;
+                chain.apply_changeset(&changeset.local_chain)?;
                 chain
             });
 


### PR DESCRIPTION
- Remove some unneeded trait bounds
- Use same default generic for CP, LocalChain, ChangeSet
- Forward to generic methods when possible

`checkpoint.rs`

- Add `CheckPoint::from_block_data`
- Move `eq_ptr` to impl CheckPoint<H> (any H)
- No default generic for `CheckPointIter`

`local_chain.rs`

- Add generic `from_genesis` data
- Make more methods generic
- Reduce code duplication
- Make `merge_chains` generic

Some methods could have more relaxed bounds (`from_tip`), but the general idea is to separate the immutable methods (`iter`) from the constructors and mutable ones, and to minimize the number of methods which only exist for `LocalChain<BlockHash>`.
